### PR TITLE
Correct the gemspec

### DIFF
--- a/hammer_cli_foreman_virt_who_configure.gemspec
+++ b/hammer_cli_foreman_virt_who_configure.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
   s.authors       = ["Tomáš Strachota"]
   s.email         = "tstracho@redhat.com"
-  s.homepage      = "http://github.com/theforeman/hammer-cli-foreman-virt-who-configure"
-  s.license       = "GPL v3+"
+  s.homepage      = "https://github.com/theforeman/hammer-cli-foreman-virt-who-configure"
+  s.license       = "GPL-3.0+"
 
   s.summary       = %q{Plugin for configuring Virt Who}
   s.description   = <<EOF


### PR DESCRIPTION
License codes should be in SPDX 2.0 format for gem build