### PR TITLE
Unpin rake in test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
 group :test do
-  gem 'rake', '~> 10.1.0'
+  gem 'rake'
   gem 'thor'
   gem 'minitest', '4.7.4'
   gem 'minitest-spec-context'


### PR DESCRIPTION
Rake should generally work and not pinned to a certain version. This fixes a security issue.