### PR TITLE
Fixes #28517 - Use system ruby while executing script

### DIFF
--- a/lib/hammer_cli_foreman_virt_who_configure/system_caller.rb
+++ b/lib/hammer_cli_foreman_virt_who_configure/system_caller.rb
@@ -1,15 +1,27 @@
 module HammerCLIForemanVirtWhoConfigure
   class SystemCaller
+    WHITELISTED_VARS = %w[HOME USER LANG].freeze
+
     def initialize(tempfile = nil)
       @tempfile = tempfile || Tempfile.new('virt_who')
     end
 
-    def system(commad)
+    def clean_env_vars
+      # Cleaning ENV vars and keeping required vars only because,
+      # When using SCL it adds GEM_HOME and GEM_PATH ENV vars.
+      # These vars break foreman-maintain tool.
+      # This way we use system ruby to execute the bash script.
+      cleaned_env = ENV.select { |var| WHITELISTED_VARS.include?(var) || var.start_with?('LC_') }
+      cleaned_env['PATH'] = '/sbin:/bin:/usr/sbin:/usr/bin'
+      cleaned_env
+    end
+
+    def system(command)
       result = nil
       begin
-        @tempfile.write(commad)
+        @tempfile.write(command)
         @tempfile.flush # to make sure the command is complete
-        result = Kernel.system("/usr/bin/bash #{@tempfile.path}")
+        result = Kernel.system(clean_env_vars, "/usr/bin/bash #{@tempfile.path}", unsetenv_others: true)
       ensure
         @tempfile.close
         @tempfile.unlink


### PR DESCRIPTION
The bash script execution fails with could not find gem errors. This fixes it by using environment variables with Kernel.system() call.