### PR TITLE
Refs #31467 - Update proxy fields in show command

### DIFF
--- a/lib/hammer_cli_foreman_virt_who_configure/config.rb
+++ b/lib/hammer_cli_foreman_virt_who_configure/config.rb
@@ -84,8 +84,14 @@ module HammerCLIForemanVirtWhoConfigure
           field :filter_host_parents, _('Filter host parents'), Fields::Field, :hide_blank => true
           field :exclude_host_parents, _('Exclude host parents'), Fields::Field, :hide_blank => true
           field :debug, _('Debug mode'), Fields::Boolean
-          field :proxy, _('HTTP proxy')
-          field :no_proxy, _('Ignore proxy')
+          field :no_proxy, _('Ignore proxy'), Fields::Field, :hide_blank => true
+        end
+        label _('HTTP Proxy') do
+          from :http_proxy do
+            field :id, _('HTTP proxy ID'), Fields::Field, :hide_blank => true
+            field :name, _('HTTP proxy name'), Fields::Field, :hide_blank => true
+            field :url, _('HTTP proxy URL'), Fields::Field, :hide_blank => true
+          end
         end
         HammerCLIForeman::References.taxonomies(self)
       end


### PR DESCRIPTION
Requires: https://github.com/theforeman/foreman_virt_who_configure/pull/129

Output with patch:

```bash
[vagrant@dhcp181-248 ~]$ hammer virt-who-config info --id 1
General information: 
    Id:                  1
    Name:                vmware
    Hypervisor type:     esx
    Hypervisor server:   vcenter.toledo.satellite.lab.eng.rdu2.redhat.com
    Hypervisor username: sateng
    Status:              No Report Yet
Schedule:            
    Interval:       every 2 hours
    Last Report At:
Connection:          
    Satellite server:     dhcp182-208.gsslab.rdu2.redhat.com
    Hypervisor ID:        hostname
    Filtering:            Unlimited
    Filter host parents:  
    Exclude host parents: 
    Debug mode:           no
    HTTP proxy ID:        1
    Proxy URL:            http://ginger.lab.eng.rdu2.redhat.com
    Ignore proxy:
```