### PR TITLE
Refs #32201 - Add kubeconfig_path to info command

### DIFF
--- a/lib/hammer_cli_foreman_virt_who_configure/config.rb
+++ b/lib/hammer_cli_foreman_virt_who_configure/config.rb
@@ -69,6 +69,7 @@ module HammerCLIForemanVirtWhoConfigure
           field :hypervisor_type, _('Hypervisor type')
           field :hypervisor_server, _('Hypervisor server')
           field :hypervisor_username, _('Hypervisor username')
+          field :kubeconfig_path, _('Configuration file'), Fields::Field, :hide_blank => true
           field :_status, _('Status')
         end
         label _('Schedule') do


### PR DESCRIPTION
Plugin PR to expose the param:

https://github.com/theforeman/foreman_virt_who_configure/pull/131

Output of results:

```bash
[vagrant@hammer ~]$ hammer virt-who-config show --id 1
General information:
    Id:                  1
    Name:                Test
    Hypervisor type:     kubevirt
    Hypervisor server:
    Hypervisor username:
    Configuration file:  /tmp/food
    Status:              No Report Yet
Schedule:
    Interval:       every 4 hours
    Last Report At:
Connection:
    Satellite server:     devel.croberts.lan
    Hypervisor ID:        hostname
    Filtering:            Unlimited
    Filter host parents:
    Exclude host parents:
    Debug mode:           no
    Ignore proxy:
```