### PR TITLE
Refs #33429 - Add Nutanix AHV support to hammer

### DIFF
--- a/lib/hammer_cli_foreman_virt_who_configure/config.rb
+++ b/lib/hammer_cli_foreman_virt_who_configure/config.rb
@@ -70,6 +70,9 @@ module HammerCLIForemanVirtWhoConfigure
           field :hypervisor_server, _('Hypervisor server')
           field :hypervisor_username, _('Hypervisor username')
           field :kubeconfig_path, _('Configuration file'), Fields::Field, :hide_blank => true
+          field :prism_flavor, _('AHV Prism flavor'), Fields::Field, :hide_blank => true
+          field :ahv_update_interval, _('AHV update frequency'), Fields::Field, :hide_blank => true
+          field :ahv_internal_debug, _('Enable AHV debug'), Fields::Boolean
           field :_status, _('Status')
         end
         label _('Schedule') do


### PR DESCRIPTION
Plugin PR to expose the param:
https://github.com/theforeman/foreman_virt_who_configure/pull/137

Output of results:
```
[vagrant@centos7-hammer-devel hammer-cli-foreman-virt-who-configure]$ hammer virt-who-config show --id 5
General information: 
    Id:                   5
    Name:                 ahv-virt-who-config
    Hypervisor type:      ahv
    Hypervisor server:    10.8.106.20
    Hypervisor username:  admin
    AHV Prism flavor:     central
    AHV update frequency: 600
    Enable AHV debug:     true
    Status:               No Report Yet
Schedule:            
    Interval:       every 12 hours
    Last Report At:
Connection:          
    Satellite server: centos7-katello-devel.lfu.example.com
    Hypervisor ID:    hostname
    Filtering:        Unlimited
    Debug mode:       yes
HTTP Proxy:
```