### PR TITLE
Failure: Could not create the Virt Who configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'gettext', '>= 3.1.3', '< 4.0.0'
 group :test do
   gem 'rake'
   gem 'thor'
-  gem 'minitest', '4.7.4'
+  gem 'minitest', '5.18'
   gem 'minitest-spec-context'
   gem 'simplecov'
   gem 'mocha'

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ Rake::TestTask.new do |t|
   t.libs.push "lib"
   t.test_files = Dir.glob('test/**/*_test.rb')
   t.verbose = true
+  t.warning = ENV.key?('RUBY_WARNINGS')
 end
 
 namespace :pkg do


### PR DESCRIPTION
### Issue:

I started facing failure while running it against ruby v3+, I tried updating gem version and looked in updating deprecated syntax while changing the gem version. but it didn't worked and looking for help in this.

<details>
  <summary>hammer-cli-foreman-virt-who-configure: failure</summary>
  
  ```
 
# Running:

...FFFFFFFFF.F........F.................F..

Finished in 0.127228s, 337.9759 runs/s, 1344.0438 assertions/s.

  1) Failure:
virt-who-config::create#test_0003_requires --filtering-mode [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:32]:
Could not create the Virt Who configuration:
  Missing arguments for '--filtering-mode'.
.
Expected /Missing arguments for.*\[filtering_mode\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--filtering-mode'.\n".

  2) Failure:
virt-who-config::create#test_0002_requires --interval [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:27]:
Could not create the Virt Who configuration:
  Missing arguments for '--interval'.
.
Expected /Missing arguments for.*\[interval\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--interval'.\n".

  3) Failure:
virt-who-config::create#test_0008_requires --hypervisor-server [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:57]:
Could not create the Virt Who configuration:
  Missing arguments for '--hypervisor-server'.
.
Expected /Missing arguments for.*\[hypervisor_server\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--hypervisor-server'.\n".

  4) Failure:
virt-who-config::create#test_0010_requires --satellite-url [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:67]:
Could not create the Virt Who configuration:
  Missing arguments for '--satellite-url'.
.
Expected /Missing arguments for.*\[satellite_url\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--satellite-url'.\n".

  5) Failure:
virt-who-config::create#test_0001_requires --name [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:22]:
Could not create the Virt Who configuration:
  Missing arguments for '--name'.
.
Expected /Missing arguments for.*\[name\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--name'.\n".

  6) Failure:
virt-who-config::create#test_0007_validates --hypervisor-type values [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:52]:
--- expected
+++ actual
@@ -1,5 +1,5 @@
 "Could not create the Virt Who configuration:
-  Error: option '--hypervisor-type': value must be one of 'esx', 'rhevm', 'hyperv', 'xen', 'libvirt'
+  Error: Option '--hypervisor-type': Value must be one of 'esx', 'rhevm', 'hyperv', 'xen', 'libvirt'..
   
   See: 'hammer virt-who-config create --help'.
 "


  7) Failure:
virt-who-config::create#test_0005_validates --hypervisor-id values [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:42]:
--- expected
+++ actual
@@ -1,5 +1,5 @@
 "Could not create the Virt Who configuration:
-  Error: option '--hypervisor-id': value must be one of 'hostname', 'uuid', 'hwuuid'
+  Error: Option '--hypervisor-id': Value must be one of 'hostname', 'uuid', 'hwuuid'..
   
   See: 'hammer virt-who-config create --help'.
 "


  8) Failure:
virt-who-config::create#test_0006_requires --hypervisor-type [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:47]:
Could not create the Virt Who configuration:
  Missing arguments for '--hypervisor-type'.
.
Expected /Missing arguments for.*\[hypervisor_type\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--hypervisor-type'.\n".

  9) Failure:
virt-who-config::create#test_0004_requires --hypervisor-id [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:37]:
Could not create the Virt Who configuration:
  Missing arguments for '--hypervisor-id'.
.
Expected /Missing arguments for.*\[hypervisor_id\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--hypervisor-id'.\n".

 10) Failure:
virt-who-config::create#test_0009_requires --hypervisor-username [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_create_test.rb:62]:
Could not create the Virt Who configuration:
  Missing arguments for '--hypervisor-username'.
.
Expected /Missing arguments for.*\[hypervisor_username\]/ to match "Could not create the Virt Who configuration:\n  Missing arguments for '--hypervisor-username'.\n".

 11) Failure:
SystemCaller#test_0001_uses tempfile for executing the script [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/lib/hammer_cli_foreman_virt_who_configure/system_caller.rb:24]:
unexpected invocation: Kernel.system({"HOME" => "/home/akumari", "LANG" => "en_US.UTF-8", "USER" => "akumari", "PATH" => "/sbin:/bin:/usr/sbin:/usr/bin"}, "/usr/bin/bash /tmp/20230609-217829-kb5eve", {:unsetenv_others => true})
unsatisfied expectations:
- expected exactly once, invoked never: Kernel.system("/usr/bin/bash /tmp/20230609-217829-kb5eve")


 12) Failure:
virt-who-config::fetch#test_0002_stores script into a file [/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/test/functional/config/config_fetch_test.rb:34]:
--- expected
+++ actual
@@ -1 +1,4 @@
-""
+"/home/akumari/Desktop/theforeman_hammer_cli/hammer-cli-foreman-virt-who-configure/lib/hammer_cli_foreman_virt_who_configure/config.rb:141: warning: File.exists? is deprecated; use File.exist? instead
+Could not fetch the Virt Who configuration:
+  Error: no implicit conversion of Hash into Integer
+"


43 runs, 171 assertions, 12 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -I"lib:lib" /home/akumari/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/functional/config/config_create_test.rb" "test/functional/config/config_deploy_test.rb" "test/functional/config/config_fetch_test.rb" "test/functional/config/config_info_test.rb" "test/functional/config/config_list_test.rb" "test/functional/config/config_update_test.rb" "test/unit/system_caller_test.rb" ]
/home/akumari/.rbenv/versions/3.1.2/bin/bundle:25:in `load'
/home/akumari/.rbenv/versions/3.1.2/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)


```
  
</details>


### Configuration
Ruby version: 3.1.2
rbenv version: 1.2.0